### PR TITLE
Update export & Change Discord API Check

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -17,7 +17,7 @@ local function GetPlayerDiscord(discordId, cb)
     })
 end
 
-exports("IsUserUsingTag", function(src)
+exports("IsPlayerUsingTag", function(src)
     local p = promise.new()
 
     local discordId = (GetPlayerIdentifierByType(src, "discord") or ""):sub(9)


### PR DESCRIPTION
- Made export use best practices, with a promise instead of callback
- Changed checking for <User>.clan to <User>.primary_guild, as this is the option shown in their API [API Reference](https://discord.com/developers/docs/resources/user#user-object-example-user). It is best practice to follow the data structures shown in the documentation.

Additionally I changed the export name and the function that fetches discord api, just for looks :)